### PR TITLE
add try/except block around pyparsing to catch crashes

### DIFF
--- a/nlpre/separated_parenthesis.py
+++ b/nlpre/separated_parenthesis.py
@@ -64,6 +64,11 @@ class separated_parenthesis(object):
             FLAG_valid = (LP_Paran == RP_Paran) and (
                 LP_Bracket == RP_Bracket) and (LP_Curl == RP_Curl)
 
+            try:
+                tokens = self.grammar.grammar.parseString(sent)
+            except (pypar.ParseException, RuntimeError):
+                FLAG_valid = False
+
             if not FLAG_valid:
                 # On fail simply remove all parenthesis
                 sent = sent.replace('(', '')
@@ -77,16 +82,7 @@ class separated_parenthesis(object):
                 text = ' '.join(tokens)
                 doc_out.append(text)
             else:
-                # Append parenthetical sentences to end of sentence
-                # try:
-                #    tokens = self.grammar.parseString(sent)
-                # except (pypar.ParseException, RuntimeError):
-                #    FLAG_valid = False
 
-                # Known issue - pyparsing will not recognize nested
-                # parenthesis if they are different types, ie "([])"
-
-                tokens = self.grammar.grammar.parseString(sent)
                 text = self.paren_pop(tokens)
                 doc_out.extend(text)
 

--- a/tests/separated_parenthesis_tests.py
+++ b/tests/separated_parenthesis_tests.py
@@ -113,23 +113,31 @@ class Separated_Parenthesis_Tests():
 
         assert_equal(doc_right, doc_new)
 
-    def travis_example_two_parenthesis_test(self):
+    def two_parenthesis_with_punctuation_test(self):
         doc = 'Superoxide anion (A(B?)).'
         doc_right = 'Superoxide anion .\nA .\nB ?'
         doc_new = self.parser(doc)
 
         assert_equals(doc_right, doc_new)
 
-    def travis_example_test(self):
+    def mixed_parens_with_punctuation_test(self):
         doc = 'Superoxide anion (A[B?]).'
         doc_right = 'Superoxide anion AB ?\n.'
         doc_new = self.parser(doc)
 
         assert_equals(doc_right, doc_new)
 
-    def travis_example_bigger_sentence_test(self):
+    def mixed_parens_with_punctuation_expanded_test(self):
         doc = 'These chemicals are (really really) great. Superoxide anion (A[B?]).'
         doc_right = 'These chemicals are great .\nreally really .\nSuperoxide anion AB ?\n.'
+        doc_new = self.parser(doc)
+
+        assert_equals(doc_right, doc_new)
+
+    def multiple_mixed_parens_with_punctuation_test(self):
+        doc = 'Low-activity state ([?]19 DIV) followed by ([?]20 DIV)'
+        doc_right = 'Low-activity state ?\n19 DIV followed by ?\n20 DIV'
+
         doc_new = self.parser(doc)
 
         assert_equals(doc_right, doc_new)


### PR DESCRIPTION
I returned the try/except block that was found in the original code that you wrote. If pyparsing fails, then it will simply remove all parenthesis. 

Looking over the old code, it looks like it would have also split on punctuation that is found in parenthetical content, so this is an appropriate fix. The code I wrote to extract parenthetical content (rather than delete it) does not 'lose' information that would have been in the original code, or create additional errors. This code is triggered in the same location as where the original content-deleting code was found. 